### PR TITLE
Fix tipuesearch by removing async script attrib (#18)

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,10 +14,10 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
 
     <link rel="stylesheet" href="{{ "/assets/tipuesearch/css/normalize.css" | relative_url }}">
-    <script async src="{{ "/assets/tipuesearch/tipuesearch_content.js" | relative_url }}"></script>
+    <script src="{{ "/assets/tipuesearch/tipuesearch_content.js" | relative_url }}"></script>
     <link rel="stylesheet" href="{{ "/assets/tipuesearch/css/tipuesearch.css" | relative_url }}">
-    <script async src="{{ "/assets/tipuesearch/tipuesearch_set.js" | relative_url }}"></script>
-    <script async src="{{ "/assets/tipuesearch/tipuesearch.min.js" | relative_url }}"></script>
+    <script src="{{ "/assets/tipuesearch/tipuesearch_set.js" | relative_url }}"></script>
+    <script src="{{ "/assets/tipuesearch/tipuesearch.min.js" | relative_url }}"></script>
   </head>
   <body>
     <div class="sidebar" style="overflow-x: hidden">


### PR DESCRIPTION
The tipuesearch plugin was being loaded with a `<script async>` tag which resulted in an occasional error about `tipuesearch` not being defined when the `$(document).ready()` function is run. Removing the `async` attributed fixed this issue, and should result in a negligible performance hit.