### PR TITLE
Fix typo: "valut" -> vault

### DIFF
--- a/JSONRPC-parity-module.md
+++ b/JSONRPC-parity-module.md
@@ -686,7 +686,7 @@ Response
 
 ### parity_changeVault
 
-Changes the current valut for the account
+Changes the current vault for the account
 
 #### Parameters
 


### PR DESCRIPTION
This is a trivial typo fix.