### PR TITLE
Update default configuration for Auto_update

### DIFF
--- a/Configuring-Parity.md
+++ b/Configuring-Parity.md
@@ -28,7 +28,7 @@ The following is a representation of a configuration file with all default value
 mode = "last"
 mode_timeout = 300
 mode_alarm = 3600
-auto_update = "none"
+auto_update = "critical"
 release_track = "current"
 public_node = false
 no_download = false


### PR DESCRIPTION
The CLI help and default *.toml file are contradictory (the first say _critical_ is default, the other _none_ ).
It seems that _critical_ is the default as @Melvillian reported in gitter chat that he got his 1.7 updated to 1.9.5 automatically.

Could you please confirm ?