### PR TITLE
link out to github issues

### DIFF
--- a/_includes/_Sidebar.md
+++ b/_includes/_Sidebar.md
@@ -83,7 +83,7 @@
 
 ### Hacking
 - [Parity Ethereum Style Guide](Parity-Ethereum-Style-Guide)
-- [Known Issues](Known-Issues-Priorities)
+- [Known Issues](https://github.com/paritytech/parity-ethereum/issues) <i class="fa fa-external-link"></i>
 - [Fuzz Testing](Fuzz-Testing)
 - [Labeling](Labelling)
 - [Release Notes](https://github.com/paritytech/parity-ethereum/blob/master/CHANGELOG.md) <i class="fa fa-external-link"></i>


### PR DESCRIPTION
Instead of using the outdated known issues page we have on the wiki.

We don't need to constantly update the page - might be a better idea to use issue pinning and better labelling on github. 