### PR TITLE
missing transactionHash in response of trace_replayBlockTransactions method in the docs

### DIFF
--- a/JSONRPC-trace-module.md
+++ b/JSONRPC-trace-module.md
@@ -315,6 +315,7 @@ Response
         "traceAddress": [],
         "type": "call"
       }],
+      "transactionHash": "0x...",
       "vmTrace": null
     },
     { ... }


### PR DESCRIPTION
Here is the formatted actual response from Parity 2.7.1 stable release on xDai chain:

Request:
`{"method":"trace_replayBlockTransactions","params":["0x7D0B6A",["trace"]],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" -X POST`

Response:
```
{
	"jsonrpc": "2.0",
	"result": [{
		"output": "0x0000000000000000000000000000000000000000000000000000000000000001",
		"stateDiff": null,
		"trace": [{
			"action": {
				"callType": "call",
				"from": "0x2a085b419358a0f309775d04528478de0dab5522",
				"gas": "0x77d2",
				"input": "0x23b872dd000000000000000000000000bdb3bc887c3b70586bc25d04d89ec802b897fc5f00000000000000000000000062e876526a73fb7e61dfa5ab660503030fb56fe5000000000000000000000000000000000000000000000015af1d78b58c400000",
				"to": "0x0fd6e8f2320c90e9d4b3a5bd888c4d556d20abd4",
				"value": "0x0"
			},
			"result": {
				"gasUsed": "0x5585",
				"output": "0x0000000000000000000000000000000000000000000000000000000000000001"
			},
			"subtraces": 0,
			"traceAddress": [],
			"type": "call"
		}],
		"transactionHash": "0xc7437aa7c9a466cd6d3daea60a2d7d35bc9ccee388681513678a97aeeee6ebb2",
		"vmTrace": null
	}, {
		"output": "0x",
		"stateDiff": null,
		"trace": [{
			"action": {
				"callType": "call",
				"from": "0xb76756f95a9fb6ff9ad3e6cb41b734c1bd805103",
				"gas": "0x0",
				"input": "0x",
				"to": "0x695741991a0cab4b92a3d06d8297a261cfd679be",
				"value": "0x13abbead789800"
			},
			"result": {
				"gasUsed": "0x0",
				"output": "0x"
			},
			"subtraces": 0,
			"traceAddress": [],
			"type": "call"
		}],
		"transactionHash": "0x1843b9fcb0d2270ca8cff4bc2546432822a7c411f6bc5f339b3adf1c53cbcf1b",
		"vmTrace": null
	}],
	"id": 1
}
```